### PR TITLE
Add HybridTACC with Auto/Manual modes, smoothness tuning, switch delay, learner, and SDpilot Developer UI

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -128,6 +128,7 @@ struct OnroadEvent @0xc4fa6047f024e718 {
     personalityChanged @91;
     aeb @92;
     userFlag @95;
+    hybridTaccActive @96;
 
     soundsUnavailableDEPRECATED @47;
   }
@@ -863,6 +864,7 @@ struct ControlsState @0x97ff69c53601abf1 {
   curvature @37 :Float32;  # path curvature from vehicle model
   desiredCurvature @61 :Float32;  # lag adjusted curvatures used by lateral controllers
   forceDecel @51 :Bool;
+  hybridTaccStatus @63 :Text;
 
   lateralControlState :union {
     pidState @53 :LateralPIDState;

--- a/common/params.py
+++ b/common/params.py
@@ -3,6 +3,15 @@ assert Params
 assert ParamKeyType
 assert UnknownKeyName
 
+# Default values for HybridTACC parameters
+HYBRID_TACC_DEFAULTS = {
+  "HybridTACCEnabled": "0",
+  "HybridTACCMode": "Auto",
+  "HybridTACCSmoothness": "0.5",
+  "HybridTACCSwitchDelay": "1.0",
+  "HybridTACCLearnerEnabled": "0",
+}
+
 if __name__ == "__main__":
   import sys
 

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -181,6 +181,12 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
     {"DynamicExperimentalControl", PERSISTENT},
     {"BlindSpot", PERSISTENT | BACKUP},
 
+    {"HybridTACCEnabled", PERSISTENT | BACKUP},
+    {"HybridTACCMode", PERSISTENT | BACKUP},
+    {"HybridTACCSmoothness", PERSISTENT | BACKUP},
+    {"HybridTACCSwitchDelay", PERSISTENT | BACKUP},
+    {"HybridTACCLearnerEnabled", PERSISTENT | BACKUP},
+
     // model panel params
     {"LagdToggle", PERSISTENT | BACKUP},
     {"LagdToggleDesc", PERSISTENT},

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -22,6 +22,8 @@ from openpilot.selfdrive.controls.lib.longcontrol import LongControl
 from openpilot.selfdrive.locationd.helpers import PoseCalibrator, Pose
 
 from openpilot.sunnypilot.selfdrive.controls.controlsd_ext import ControlsExt
+from openpilot.selfdrive.controls.hybrid_tacc_learner import HybridTACCLearner
+from openpilot.selfdrive.selfdrived.events import EventName
 
 State = log.SelfdriveState.OpenpilotState
 LaneChangeState = log.LaneChangeState
@@ -42,10 +44,11 @@ class Controls(ControlsExt):
 
     self.CI = interfaces[self.CP.carFingerprint](self.CP, self.CP_SP)
 
-    self.sm = messaging.SubMaster(['liveParameters', 'liveTorqueParameters', 'modelV2', 'selfdriveState',
-                                   'liveCalibration', 'livePose', 'longitudinalPlan', 'carState', 'carOutput',
-                                   'driverMonitoringState', 'onroadEvents', 'driverAssistance', 'liveDelay'] + self.sm_services_ext,
-                                  poll='selfdriveState')
+    self.sm = messaging.SubMaster(
+      ['liveParameters', 'liveTorqueParameters', 'modelV2', 'selfdriveState',
+       'liveCalibration', 'livePose', 'longitudinalPlan', 'carState', 'carOutput',
+       'driverMonitoringState', 'onroadEvents', 'driverAssistance', 'liveDelay', 'radarState'] + self.sm_services_ext,
+      poll='selfdriveState')
     self.pm = messaging.PubMaster(['carControl', 'controlsState'] + self.pm_services_ext)
 
     self.steer_limited_by_controls = False
@@ -65,6 +68,23 @@ class Controls(ControlsExt):
     elif self.CP.lateralTuning.which() == 'torque':
       self.LaC = LatControlTorque(self.CP, self.CP_SP, self.CI)
 
+    # HybridTACC setup
+    self.hybrid_params = {
+      "enabled": self.params.get_bool("HybridTACCEnabled"),
+      "mode": (self.params.get("HybridTACCMode") or b"Auto").decode(),
+      "smoothness": float(self.params.get("HybridTACCSmoothness") or b"0.5"),
+      "switch_delay": float(self.params.get("HybridTACCSwitchDelay") or b"1.0"),
+      "learner_enabled": self.params.get_bool("HybridTACCLearnerEnabled"),
+    }
+    self.hybrid_learner = HybridTACCLearner() if self.hybrid_params["learner_enabled"] else None
+    if self.hybrid_params["mode"] == "Auto" and self.hybrid_learner:
+      self.hybrid_params["smoothness"] = self.hybrid_learner.smoothness
+      self.hybrid_params["switch_delay"] = self.hybrid_learner.switch_delay
+    self.hybrid_source = "vision"
+    self.hybrid_accel = 0.0
+    self.hybrid_last_switch = 0.0
+    self.hybrid_status = ""
+
   def update(self):
     self.sm.update(15)
     if self.sm.updated["liveCalibration"]:
@@ -75,6 +95,7 @@ class Controls(ControlsExt):
 
   def state_control(self):
     CS = self.sm['carState']
+    events = self.sm['onroadEvents']
 
     # Update VehicleModel
     lp = self.sm['liveParameters']
@@ -128,6 +149,41 @@ class Controls(ControlsExt):
     # accel PID loop
     pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, CS.vCruise * CV.KPH_TO_MS)
     actuators.accel = float(self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop, pid_accel_limits))
+
+    if self.hybrid_params["enabled"]:
+      radar_state = self.sm['radarState']
+      radar_valid = getattr(radar_state.leadOne, "status", False) and getattr(radar_state.leadOne, "radar", False)
+      target_source = "radar" if radar_valid else "vision"
+
+      # use learner or manual parameters
+      alpha = self.hybrid_params["smoothness"]
+      delay = self.hybrid_params["switch_delay"]
+      if self.hybrid_params["mode"] == "Auto" and self.hybrid_learner:
+        alpha = self.hybrid_learner.smoothness
+        delay = self.hybrid_learner.switch_delay
+
+      t = time.monotonic()
+      if target_source != self.hybrid_source and t - self.hybrid_last_switch >= delay:
+        self.hybrid_source = target_source
+        self.hybrid_last_switch = t
+
+      source = self.hybrid_source
+      if source == "radar" and radar_valid:
+        target_accel = radar_state.leadOne.aRel
+      else:
+        target_accel = long_plan.aTarget
+        source = "vision"
+
+      self.hybrid_accel = alpha * self.hybrid_accel + (1.0 - alpha) * target_accel
+      actuators.accel = float(self.hybrid_accel)
+      self.hybrid_status = source
+      events.add(EventName.hybridTaccActive)
+
+      if self.hybrid_params["learner_enabled"] and self.hybrid_learner:
+        self.hybrid_params["smoothness"], self.hybrid_params["switch_delay"] = self.hybrid_learner.update(
+          source, CS, radar_state, model_v2)
+    else:
+      self.hybrid_status = ""
 
     # Steering PID loop and lateral MPC
     # Reset desired curvature to current to avoid violating the limits on engage
@@ -209,6 +265,8 @@ class Controls(ControlsExt):
     cs.ufAccelCmd = float(self.LoC.pid.f)
     cs.forceDecel = bool((self.sm['driverMonitoringState'].awarenessStatus < 0.) or
                          (self.sm['selfdriveState'].state == State.softDisabling))
+    if self.hybrid_status:
+      cs.hybridTaccStatus = self.hybrid_status
 
     lat_tuning = self.CP.lateralTuning.which()
     if self.CP.steerControlType == car.CarParams.SteerControlType.angle:

--- a/selfdrive/controls/hybrid_tacc_learner.py
+++ b/selfdrive/controls/hybrid_tacc_learner.py
@@ -1,0 +1,46 @@
+import json
+import os
+
+
+class HybridTACCLearner:
+  """Simple learner for HybridTACC parameters."""
+
+  def __init__(self, storage_path: str = "/data/hybrid_tacc/learner.json"):
+    self.storage_path = storage_path
+    self.smoothness = 0.5
+    self.switch_delay = 1.0
+    self._load()
+
+  def _load(self) -> None:
+    try:
+      with open(self.storage_path, "r") as f:
+        data = json.load(f)
+        self.smoothness = float(data.get("smoothness", self.smoothness))
+        self.switch_delay = float(data.get("switch_delay", self.switch_delay))
+    except Exception:
+      pass
+
+  def _save(self) -> None:
+    os.makedirs(os.path.dirname(self.storage_path), exist_ok=True)
+    with open(self.storage_path, "w") as f:
+      json.dump({"smoothness": self.smoothness, "switch_delay": self.switch_delay}, f)
+
+  def update(self, decision, car_state, radar_state, model_state) -> tuple[float, float]:
+    """Update learner with latest driving data.
+
+    This is a very lightweight learner that nudges parameters based on
+    radar availability. It persists updated values to disk and returns
+    the latest smoothness and switch delay.
+    """
+
+    if getattr(radar_state.leadOne, "status", False):
+      self.smoothness = min(1.0, self.smoothness + 0.01)
+    else:
+      self.smoothness = max(0.0, self.smoothness - 0.01)
+
+    # Keep switch delay within bounds
+    self.switch_delay = min(3.0, max(0.1, self.switch_delay))
+
+    self._save()
+    return self.smoothness, self.switch_delay
+

--- a/selfdrive/selfdrived/events.py
+++ b/selfdrive/selfdrived/events.py
@@ -254,6 +254,10 @@ EVENTS: dict[int, dict[str, Alert | AlertCallbackType]] = {
                                        priority=Priority.LOWEST),
   },
 
+  EventName.hybridTaccActive: {
+    ET.WARNING: NormalPermanentAlert("HybridTACC active"),
+  },
+
   EventName.invalidLkasSetting: {
     ET.PERMANENT: invalid_lkas_setting_alert,
     ET.NO_ENTRY: NoEntryAlert("Invalid LKAS setting"),

--- a/selfdrive/ui/layouts/settings/sdpilot_developer.py
+++ b/selfdrive/ui/layouts/settings/sdpilot_developer.py
@@ -1,0 +1,87 @@
+from openpilot.system.ui.lib.list_view import toggle_item, multiple_button_item, dual_button_item
+from openpilot.system.ui.lib.scroller import Scroller
+from openpilot.system.ui.lib.widget import Widget
+from openpilot.common.params import Params
+
+
+class SDpilotDeveloperLayout(Widget):
+  def __init__(self):
+    super().__init__()
+    self._params = Params()
+
+    self._mode = (self._params.get("HybridTACCMode") or b"Auto").decode()
+    self._mode_index = 0 if self._mode == "Manual" else 1
+    self._smoothness = float(self._params.get("HybridTACCSmoothness") or b"0.5")
+    self._switch_delay = float(self._params.get("HybridTACCSwitchDelay") or b"1.0")
+
+    items = [
+      toggle_item(
+        "Enable HybridTACC",
+        initial_state=self._params.get_bool("HybridTACCEnabled"),
+        callback=self._toggle_enabled,
+      ),
+      multiple_button_item(
+        "HybridTACC Mode",
+        "",
+        buttons=["Manual", "Auto"],
+        selected_index=self._mode_index,
+        callback=self._set_mode,
+      ),
+      dual_button_item(
+        "-",
+        "+",
+        self._dec_smoothness,
+        self._inc_smoothness,
+        description=lambda: f"Smoothness: {self._smoothness:.2f}",
+        enabled=lambda: self._mode_index == 0,
+      ),
+      dual_button_item(
+        "-",
+        "+",
+        self._dec_delay,
+        self._inc_delay,
+        description=lambda: f"Switch Delay: {self._switch_delay:.1f}s",
+        enabled=lambda: self._mode_index == 0,
+      ),
+      toggle_item(
+        "Enable HybridTACC Learner",
+        initial_state=self._params.get_bool("HybridTACCLearnerEnabled"),
+        callback=self._toggle_learner,
+      ),
+    ]
+
+    self._scroller = Scroller(items, line_separator=True, spacing=0)
+
+  def _render(self, rect):
+    self._scroller.render(rect)
+
+  # Callbacks
+  def _toggle_enabled(self):
+    current = self._params.get_bool("HybridTACCEnabled")
+    self._params.put_bool("HybridTACCEnabled", not current)
+
+  def _toggle_learner(self):
+    current = self._params.get_bool("HybridTACCLearnerEnabled")
+    self._params.put_bool("HybridTACCLearnerEnabled", not current)
+
+  def _set_mode(self, index: int):
+    self._mode_index = index
+    self._mode = "Manual" if index == 0 else "Auto"
+    self._params.put("HybridTACCMode", self._mode)
+
+  def _dec_smoothness(self):
+    self._smoothness = max(0.0, self._smoothness - 0.05)
+    self._params.put("HybridTACCSmoothness", f"{self._smoothness:.2f}")
+
+  def _inc_smoothness(self):
+    self._smoothness = min(1.0, self._smoothness + 0.05)
+    self._params.put("HybridTACCSmoothness", f"{self._smoothness:.2f}")
+
+  def _dec_delay(self):
+    self._switch_delay = max(0.1, self._switch_delay - 0.1)
+    self._params.put("HybridTACCSwitchDelay", f"{self._switch_delay:.1f}")
+
+  def _inc_delay(self):
+    self._switch_delay = min(3.0, self._switch_delay + 0.1)
+    self._params.put("HybridTACCSwitchDelay", f"{self._switch_delay:.1f}")
+

--- a/selfdrive/ui/layouts/settings/settings.py
+++ b/selfdrive/ui/layouts/settings/settings.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from collections.abc import Callable
 from openpilot.selfdrive.ui.layouts.settings.developer import DeveloperLayout
+from openpilot.selfdrive.ui.layouts.settings.sdpilot_developer import SDpilotDeveloperLayout
 from openpilot.selfdrive.ui.layouts.settings.device import DeviceLayout
 from openpilot.selfdrive.ui.layouts.settings.firehose import FirehoseLayout
 from openpilot.selfdrive.ui.layouts.settings.software import SoftwareLayout
@@ -37,6 +38,7 @@ class PanelType(IntEnum):
   SOFTWARE = 3
   FIREHOSE = 4
   DEVELOPER = 5
+  SDPILOT_DEVELOPER = 6
 
 
 @dataclass
@@ -59,6 +61,7 @@ class SettingsLayout(Widget):
       PanelType.SOFTWARE: PanelInfo("Software", SoftwareLayout()),
       PanelType.FIREHOSE: PanelInfo("Firehose", FirehoseLayout()),
       PanelType.DEVELOPER: PanelInfo("Developer", DeveloperLayout()),
+      PanelType.SDPILOT_DEVELOPER: PanelInfo("SDpilot Developer", SDpilotDeveloperLayout()),
     }
 
     self._font_medium = gui_app.font(FontWeight.MEDIUM)

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -84,6 +84,11 @@ class TogglesLayout(Widget):
       toggle_item(
         "Use Metric System", DESCRIPTIONS["IsMetric"], self._params.get_bool("IsMetric"), icon="monitoring.png"
       ),
+      toggle_item(
+        "HybridTACC (Beta)",
+        "",
+        self._params.get_bool("HybridTACCEnabled"),
+      ),
     ]
 
     self._scroller = Scroller(items, line_separator=True, spacing=0)

--- a/selfdrive/ui/onroad/hud_renderer.py
+++ b/selfdrive/ui/onroad/hud_renderer.py
@@ -120,6 +120,8 @@ class HudRenderer(Widget):
     button_y = rect.y + UI_CONFIG.border_size
     self._exp_button.render(rl.Rectangle(button_x, button_y, UI_CONFIG.button_size, UI_CONFIG.button_size))
 
+    self._draw_hybrid_tacc(rect)
+
   def handle_mouse_event(self) -> bool:
     return bool(self._exp_button.handle_mouse_event())
 
@@ -177,3 +179,20 @@ class HudRenderer(Widget):
     unit_text_size = measure_text_cached(self._font_medium, unit_text, FONT_SIZES.speed_unit)
     unit_pos = rl.Vector2(rect.x + rect.width / 2 - unit_text_size.x / 2, 290 - unit_text_size.y / 2)
     rl.draw_text_ex(self._font_medium, unit_text, unit_pos, FONT_SIZES.speed_unit, 0, COLORS.white_translucent)
+
+  def _draw_hybrid_tacc(self, rect: rl.Rectangle) -> None:
+    if not ui_state.params.get_bool("HybridTACCEnabled"):
+      return
+    status = ui_state.sm['controlsState'].hybridTaccStatus
+    if not status:
+      return
+    text = f"HybridTACC: {status.capitalize()}"
+    if (ui_state.params.get("HybridTACCMode") or b"Auto").decode() == "Auto":
+      text += " Auto-Tuned"
+    if ui_state.params.get_bool("HybridTACCLearnerEnabled"):
+      text += " Learner Active"
+
+    text_size = measure_text_cached(self._font_medium, text, 40)
+    x = rect.x + (rect.width - text_size.x) / 2
+    y = rect.y + rect.height - 80
+    rl.draw_text_ex(self._font_medium, text, rl.Vector2(x, y), 40, 0, COLORS.white)


### PR DESCRIPTION

- add persistent HybridTACC parameters and defaults
- implement HybridTACCLearner and integrate Auto/Manual smoothing, delay, radar/vision switching
- expose controls in new SDpilot Developer panel and HUD overlay
- fix SubMaster initialization and emit HybridTACC active alert
