### PR TITLE
Add Hybrid TACC parameters and controls

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -1,4 +1,5 @@
 using Cxx = import "./include/c++.capnp";
+using Car = import "car.capnp";
 $Cxx.namespace("cereal");
 
 @0xb526ba661d550a59;
@@ -151,6 +152,8 @@ struct OnroadEventSP @0xda96579883444c35 {
     experimentalModeSwitched @14;
     wrongCarModeAlertOnly @15;
     pedalPressedAlertOnly @16;
+    hybridTaccActive @17;
+    hybridTaccAutoSwitch @18;
   }
 }
 
@@ -159,6 +162,9 @@ struct CarParamsSP @0x80ae746ee2596b11 {
   safetyParam @1 : Int16;  # flags for sunnypilot's custom safety flags
 
   neuralNetworkLateralControl @2 :NeuralNetworkLateralControl;
+  HybridTACC_Smoothness @3 :Float32;
+  HybridTACC_Responsiveness @4 :Float32;
+  HybridTACC_SwitchBias @5 :Float32;
 
   struct NeuralNetworkLateralControl {
     model @0 :Model;
@@ -174,6 +180,9 @@ struct CarParamsSP @0x80ae746ee2596b11 {
 struct CarControlSP @0xa5cd762cd951a455 {
   mads @0 :ModularAssistiveDrivingSystem;
   params @1 :List(Param);
+  hybridTACCEnabled @2 :Bool;
+  experimentalMode @3 :Bool;
+  visualAlert @4 :Car.CarControl.HUDControl.VisualAlert;
 
   struct Param {
     key @0 :Text;

--- a/selfdrive/assets/icons/hybrid_tacc.png
+++ b/selfdrive/assets/icons/hybrid_tacc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/assets/icons/responsiveness.png
+++ b/selfdrive/assets/icons/responsiveness.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/assets/icons/smoothness.png
+++ b/selfdrive/assets/icons/smoothness.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/assets/icons/switch_bias.png
+++ b/selfdrive/assets/icons/switch_bias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -4,7 +4,7 @@ import threading
 import time
 from typing import SupportsFloat
 
-from cereal import car, log
+from cereal import car, log, custom
 import cereal.messaging as messaging
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.params import Params
@@ -46,11 +46,13 @@ class Controls(ControlsExt):
                                    'liveCalibration', 'livePose', 'longitudinalPlan', 'carState', 'carOutput',
                                    'driverMonitoringState', 'onroadEvents', 'driverAssistance', 'liveDelay'] + self.sm_services_ext,
                                   poll='selfdriveState')
-    self.pm = messaging.PubMaster(['carControl', 'controlsState'] + self.pm_services_ext)
+    self.pm = messaging.PubMaster(['carControl', 'controlsState', 'onroadEventsSP'] + self.pm_services_ext)
 
     self.steer_limited_by_controls = False
     self.curvature = 0.0
     self.desired_curvature = 0.0
+    self.hybrid_tacc_active = False
+    self.hybrid_tacc_auto_switch = False
 
     self.pose_calibrator = PoseCalibrator()
     self.calibrated_pose: Pose | None = None
@@ -98,6 +100,17 @@ class Controls(ControlsExt):
 
     long_plan = self.sm['longitudinalPlan']
     model_v2 = self.sm['modelV2']
+    hybrid_prev_active = self.hybrid_tacc_active
+    self.hybrid_tacc_auto_switch = False
+    if self.hybrid_tacc_enabled:
+      if self.sm['selfdriveState'].experimentalMode and self.hybrid_tacc_switch_bias >= 0.5:
+        self.hybrid_tacc_active = True
+      else:
+        self.hybrid_tacc_active = False
+      if self.hybrid_tacc_active != hybrid_prev_active:
+        self.hybrid_tacc_auto_switch = True
+    else:
+      self.hybrid_tacc_active = False
 
     CC = car.CarControl.new_message()
     CC.enabled = self.sm['selfdriveState'].enabled
@@ -127,7 +140,12 @@ class Controls(ControlsExt):
 
     # accel PID loop
     pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, CS.vCruise * CV.KPH_TO_MS)
-    actuators.accel = float(self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop, pid_accel_limits))
+    a_target = long_plan.aTarget
+    if self.hybrid_tacc_enabled:
+      a_target *= self.hybrid_tacc_smoothness
+    actuators.accel = float(self.LoC.update(CC.longActive, CS, a_target, long_plan.shouldStop, pid_accel_limits))
+    if self.hybrid_tacc_enabled:
+      actuators.accel *= self.hybrid_tacc_responsiveness
 
     # Steering PID loop and lateral MPC
     # Reset desired curvature to current to avoid violating the limits on engage
@@ -149,6 +167,17 @@ class Controls(ControlsExt):
       if not math.isfinite(attr):
         cloudlog.error(f"actuators.{p} not finite {actuators.to_dict()}")
         setattr(actuators, p, 0.0)
+
+    if self.hybrid_tacc_enabled:
+      bias_changed = False
+      if self.hybrid_tacc_active and CS.brakePressed:
+        self.hybrid_tacc_switch_bias = max(0.0, self.hybrid_tacc_switch_bias - 0.01)
+        bias_changed = True
+      elif not self.hybrid_tacc_active and CS.gasPressed:
+        self.hybrid_tacc_switch_bias = min(1.0, self.hybrid_tacc_switch_bias + 0.01)
+        bias_changed = True
+      if bias_changed:
+        self.params.put("HybridTACC_SwitchBias", f"{self.hybrid_tacc_switch_bias:.2f}")
 
     return CC, lac_log
 
@@ -225,6 +254,21 @@ class Controls(ControlsExt):
     cc_send.valid = CS.canValid
     cc_send.carControl = CC
     self.pm.send('carControl', cc_send)
+
+    if self.hybrid_tacc_enabled:
+      events = []
+      if self.hybrid_tacc_active:
+        e = custom.OnroadEventSP.Event.new_message()
+        e.name = custom.OnroadEventSP.EventName.hybridTaccActive
+        events.append(e)
+      if self.hybrid_tacc_auto_switch:
+        e = custom.OnroadEventSP.Event.new_message()
+        e.name = custom.OnroadEventSP.EventName.hybridTaccAutoSwitch
+        events.append(e)
+      if events:
+        ce_send = messaging.new_message('onroadEventsSP')
+        ce_send.onroadEventsSP.events = events
+        self.pm.send('onroadEventsSP', ce_send)
 
   def params_thread(self, evt):
     while not evt.is_set():

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -1,4 +1,4 @@
-from openpilot.system.ui.lib.list_view import multiple_button_item, toggle_item
+from openpilot.system.ui.lib.list_view import multiple_button_item, toggle_item, slider_item
 from openpilot.system.ui.lib.scroller import Scroller
 from openpilot.system.ui.lib.widget import Widget
 from openpilot.common.params import Params
@@ -84,6 +84,33 @@ class TogglesLayout(Widget):
       toggle_item(
         "Use Metric System", DESCRIPTIONS["IsMetric"], self._params.get_bool("IsMetric"), icon="monitoring.png"
       ),
+      toggle_item(
+        "HybridTACC (Beta)",
+        initial_state=self._params.get_bool("HybridTACCEnabled"),
+        icon="hybrid_tacc.png",
+        callback=self._toggle_hybrid_tacc,
+      ),
+      slider_item(
+        "Smoothness",
+        "Smooth \u2194 Aggressive",
+        float(self._params.get("HybridTACC_Smoothness") or 0.5),
+        lambda v: self._params.put("HybridTACC_Smoothness", f"{v:.2f}"),
+        icon="smoothness.png",
+      ),
+      slider_item(
+        "Responsiveness",
+        "Comfort \u2194 Responsive",
+        float(self._params.get("HybridTACC_Responsiveness") or 0.5),
+        lambda v: self._params.put("HybridTACC_Responsiveness", f"{v:.2f}"),
+        icon="responsiveness.png",
+      ),
+      slider_item(
+        "Switch Bias",
+        "Conservative \u2194 Experimental",
+        float(self._params.get("HybridTACC_SwitchBias") or 0.5),
+        lambda v: self._params.put("HybridTACC_SwitchBias", f"{v:.2f}"),
+        icon="switch_bias.png",
+      ),
     ]
 
     self._scroller = Scroller(items, line_separator=True, spacing=0)
@@ -93,3 +120,6 @@ class TogglesLayout(Widget):
 
   def _set_longitudinal_personality(self, button_index: int):
     self._params.put("LongitudinalPersonality", str(button_index))
+
+  def _toggle_hybrid_tacc(self):
+    self._params.put_bool("HybridTACCEnabled", not self._params.get_bool("HybridTACCEnabled"))

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -1,7 +1,8 @@
 import time
 import pyray as rl
 from dataclasses import dataclass
-from cereal import messaging, log
+from cereal import messaging, log, custom
+import os
 from openpilot.system.hardware import TICI
 from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_FPS
 from openpilot.system.ui.lib.label import gui_text_box
@@ -35,6 +36,7 @@ class Alert:
   text2: str = ""
   size: int = 0
   status: int = 0
+  icon: str | None = None
 
 
 # Pre-defined alert instances
@@ -89,11 +91,25 @@ class AlertRenderer(Widget):
           return ALERT_CRITICAL_REBOOT
 
     # No alert if size is none
-    if ss.alertSize == 0:
-      return None
+    if ss.alertSize != 0:
+      return Alert(text1=ss.alertText1, text2=ss.alertText2, size=ss.alertSize, status=ss.alertStatus)
 
-    # Return current alert
-    return Alert(text1=ss.alertText1, text2=ss.alertText2, size=ss.alertSize, status=ss.alertStatus)
+    for e in sm['onroadEventsSP'].events:
+      if e.name == custom.OnroadEventSP.EventName.hybridTaccAutoSwitch:
+        return Alert(
+          text1="Hybrid TACC Auto Switch",
+          size=log.SelfdriveState.AlertSize.mid,
+          status=log.SelfdriveState.AlertStatus.userPrompt,
+          icon="hybrid_tacc.png",
+        )
+      if e.name == custom.OnroadEventSP.EventName.hybridTaccActive:
+        return Alert(
+          text1="Hybrid TACC Active",
+          size=log.SelfdriveState.AlertSize.small,
+          status=log.SelfdriveState.AlertStatus.normal,
+          icon="hybrid_tacc.png",
+        )
+    return None
 
   def _render(self, rect: rl.Rectangle) -> bool:
     alert = self.get_alert(ui_state.sm)
@@ -136,6 +152,12 @@ class AlertRenderer(Widget):
       rl.draw_rectangle_rec(rect, color)
 
   def _draw_text(self, rect: rl.Rectangle, alert: Alert) -> None:
+    if alert.icon:
+      icon_tex = gui_app.texture(os.path.join("icons", alert.icon), 80, 80)
+      rl.draw_texture(icon_tex, int(rect.x), int(rect.y + (rect.height - 80) / 2), rl.WHITE)
+      rect.x += 100
+      rect.width -= 100
+
     if alert.size == log.SelfdriveState.AlertSize.small:
       self._draw_centered(alert.text1, rect, self.font_bold, ALERT_FONT_MEDIUM)
 

--- a/sunnypilot/selfdrive/controls/controlsd_ext.py
+++ b/sunnypilot/selfdrive/controls/controlsd_ext.py
@@ -20,6 +20,10 @@ class ControlsExt:
     self.params = params
     self.blinker_pause_lateral = BlinkerPauseLateral()
     self.param_store = ParamStore(self.CP)
+    self.hybrid_tacc_enabled = False
+    self.hybrid_tacc_smoothness = 0.5
+    self.hybrid_tacc_responsiveness = 0.5
+    self.hybrid_tacc_switch_bias = 0.5
     self.get_params_sp()
 
     cloudlog.info("controlsd_ext is waiting for CarParamsSP")
@@ -32,6 +36,10 @@ class ControlsExt:
   def get_params_sp(self) -> None:
     self.param_store.update(self.params)
     self.blinker_pause_lateral.get_params()
+    self.hybrid_tacc_enabled = self.params.get_bool("HybridTACCEnabled")
+    self.hybrid_tacc_smoothness = float(self.params.get("HybridTACC_Smoothness", encoding='utf8') or "0.5")
+    self.hybrid_tacc_responsiveness = float(self.params.get("HybridTACC_Responsiveness", encoding='utf8') or "0.5")
+    self.hybrid_tacc_switch_bias = float(self.params.get("HybridTACC_SwitchBias", encoding='utf8') or "0.5")
 
   def get_lat_active(self, sm: messaging.SubMaster) -> bool:
     if self.blinker_pause_lateral.update(sm['carState']):
@@ -49,8 +57,10 @@ class ControlsExt:
 
     # MADS state
     CC_SP.mads = sm['selfdriveStateSP'].mads
-
     CC_SP.params = self.param_store.publish()
+    CC_SP.hybridTACCEnabled = self.hybrid_tacc_enabled
+    CC_SP.experimentalMode = sm['selfdriveState'].experimentalMode
+    CC_SP.visualAlert = sm['selfdriveState'].alertHudVisual
 
     return CC_SP
 

--- a/sunnypilot/selfdrive/controls/lib/param_store.py
+++ b/sunnypilot/selfdrive/controls/lib/param_store.py
@@ -17,8 +17,24 @@ class ParamStore:
   values: dict[str, str]
 
   def __init__(self, CP: structs.CarParams):
-    universal_params: list[str] = []
+    universal_params: list[str] = [
+      "HybridTACCEnabled",
+      "HybridTACC_Smoothness",
+      "HybridTACC_Responsiveness",
+      "HybridTACC_SwitchBias",
+    ]
     brand_params: list[str] = []
+
+    p = Params()
+    defaults = {
+      "HybridTACCEnabled": "0",
+      "HybridTACC_Smoothness": "0.5",
+      "HybridTACC_Responsiveness": "0.5",
+      "HybridTACC_SwitchBias": "0.5",
+    }
+    for k, v in defaults.items():
+      if p.get(k) is None:
+        p.put(k, v)
 
     self.keys = universal_params + brand_params
     self.values = {}

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -126,6 +126,14 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
     ET.WARNING: NormalPermanentAlert("Experimental Mode Switched", duration=1.5)
   },
 
+  EventNameSP.hybridTaccActive: {
+    ET.WARNING: NormalPermanentAlert("Hybrid TACC Active", duration=1.5)
+  },
+
+  EventNameSP.hybridTaccAutoSwitch: {
+    ET.WARNING: NormalPermanentAlert("Hybrid TACC Auto Switch", duration=1.5)
+  },
+
   EventNameSP.wrongCarModeAlertOnly: {
     ET.WARNING: wrong_car_mode_alert,
   },

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -199,6 +199,44 @@ class MultipleButtonAction(ItemAction):
     return False
 
 
+class SliderAction(ItemAction):
+  def __init__(self, initial_value: float = 0.5, callback: Callable[[float], None] | None = None,
+               enabled: bool | Callable[[], bool] = True):
+    super().__init__(width=400, enabled=enabled)
+    self.value = initial_value
+    self.callback = callback
+    self._dragging = False
+
+  def _render(self, rect: rl.Rectangle) -> bool:
+    track_height = 20
+    track_rect = rl.Rectangle(rect.x, rect.y + (rect.height - track_height) / 2, self._rect.width, track_height)
+    rl.draw_rectangle_rounded(track_rect, 1.0, 20, rl.Color(57, 57, 57, 255))
+    knob_radius = 15
+    knob_x = track_rect.x + self.value * track_rect.width
+    knob_center = rl.Vector2(knob_x, track_rect.y + track_rect.height / 2)
+    rl.draw_circle_v(knob_center, knob_radius, rl.WHITE)
+
+    mouse = rl.get_mouse_position()
+    changed = False
+    if self.enabled:
+      if rl.is_mouse_button_pressed(rl.MouseButton.MOUSE_BUTTON_LEFT) and rl.check_collision_point_rec(
+          mouse, rl.Rectangle(track_rect.x - knob_radius, track_rect.y - knob_radius,
+                               track_rect.width + knob_radius * 2, track_rect.height + knob_radius * 2)):
+        self._dragging = True
+      if self._dragging:
+        if rl.is_mouse_button_down(rl.MouseButton.MOUSE_BUTTON_LEFT):
+          self.value = max(0.0, min(1.0, (mouse.x - track_rect.x) / track_rect.width))
+          changed = True
+        else:
+          self._dragging = False
+
+    if changed and self.callback:
+      self.callback(self.value)
+    return changed
+
+
+
+
 class ListItem(Widget):
   def __init__(self, title: str = "", icon: str | None = None, description: str | Callable[[], str] | None = None,
                description_visible: bool = False, callback: Callable | None = None,
@@ -365,4 +403,9 @@ def dual_button_item(left_text: str, right_text: str, left_callback: Callable = 
 def multiple_button_item(title: str, description: str, buttons: list[str], selected_index: int,
                          button_width: int = BUTTON_WIDTH, callback: Callable = None, icon: str = ""):
   action = MultipleButtonAction(buttons, button_width, selected_index, callback=callback)
+  return ListItem(title=title, description=description, icon=icon, action_item=action)
+
+
+def slider_item(title: str, description: str, initial_value: float, callback: Callable[[float], None], icon: str = ""):
+  action = SliderAction(initial_value, callback=callback)
   return ListItem(title=title, description=description, icon=icon, action_item=action)


### PR DESCRIPTION
## Summary
- extend parameter store and Cap'n Proto schemas with Hybrid TACC fields and events
- integrate Hybrid TACC toggles, sliders, and alert rendering in controls and UI
- add placeholder icons for new Hybrid TACC settings


