### PR TITLE
Add Hybrid TACC controls and alerts

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -1,4 +1,5 @@
 using Cxx = import "./include/c++.capnp";
+using car = import "./car.capnp";
 $Cxx.namespace("cereal");
 
 @0xb526ba661d550a59;
@@ -151,6 +152,8 @@ struct OnroadEventSP @0xda96579883444c35 {
     experimentalModeSwitched @14;
     wrongCarModeAlertOnly @15;
     pedalPressedAlertOnly @16;
+    hybridTaccActive @17;
+    hybridTaccAutoSwitch @18;
   }
 }
 
@@ -159,6 +162,9 @@ struct CarParamsSP @0x80ae746ee2596b11 {
   safetyParam @1 : Int16;  # flags for sunnypilot's custom safety flags
 
   neuralNetworkLateralControl @2 :NeuralNetworkLateralControl;
+  HybridTACC_Smoothness @3 :Float32;
+  HybridTACC_Responsiveness @4 :Float32;
+  HybridTACC_SwitchBias @5 :Float32;
 
   struct NeuralNetworkLateralControl {
     model @0 :Model;
@@ -174,6 +180,9 @@ struct CarParamsSP @0x80ae746ee2596b11 {
 struct CarControlSP @0xa5cd762cd951a455 {
   mads @0 :ModularAssistiveDrivingSystem;
   params @1 :List(Param);
+  hybridTACCEnabled @2 :Bool;
+  experimentalMode @3 :Bool;
+  visualAlert @4 :car.CarControl.HUDControl.VisualAlert;
 
   struct Param {
     key @0 :Text;

--- a/selfdrive/assets/icons/hybrid_tacc.png
+++ b/selfdrive/assets/icons/hybrid_tacc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/assets/icons/responsiveness.png
+++ b/selfdrive/assets/icons/responsiveness.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/assets/icons/smoothness.png
+++ b/selfdrive/assets/icons/smoothness.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/assets/icons/switch_bias.png
+++ b/selfdrive/assets/icons/switch_bias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e4d724f4bfc341ebca82d0a86de5563525ac3a4f3371235472e1d2eed3e6f2
+size 119

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -4,7 +4,7 @@ import threading
 import time
 from typing import SupportsFloat
 
-from cereal import car, log
+from cereal import car, log, custom
 import cereal.messaging as messaging
 from openpilot.common.conversions import Conversions as CV
 from openpilot.common.params import Params
@@ -39,6 +39,7 @@ class Controls(ControlsExt):
 
     # Initialize sunnypilot controlsd extension
     ControlsExt.__init__(self, self.CP, self.params)
+    self.prev_experimental_mode = self.experimental_mode
 
     self.CI = interfaces[self.CP.carFingerprint](self.CP, self.CP_SP)
 
@@ -110,7 +111,14 @@ class Controls(ControlsExt):
 
     CC.latActive = _lat_active and not CS.steerFaultTemporary and not CS.steerFaultPermanent and \
                    (not standstill or self.CP.steerAtStandstill)
-    CC.longActive = CC.enabled and not any(e.overrideLongitudinal for e in self.sm['onroadEvents']) and self.CP.openpilotLongitudinalControl
+    base_long_active = CC.enabled and not any(e.overrideLongitudinal for e in self.sm['onroadEvents'])
+    if self.hybrid_tacc_enabled:
+      if self.experimental_mode:
+        CC.longActive = base_long_active
+      else:
+        CC.longActive = False
+    else:
+      CC.longActive = base_long_active and self.CP.openpilotLongitudinalControl
 
     actuators = CC.actuators
     actuators.longControlState = self.LoC.long_control_state
@@ -127,7 +135,12 @@ class Controls(ControlsExt):
 
     # accel PID loop
     pid_accel_limits = self.CI.get_pid_accel_limits(self.CP, CS.vEgo, CS.vCruise * CV.KPH_TO_MS)
-    actuators.accel = float(self.LoC.update(CC.longActive, CS, long_plan.aTarget, long_plan.shouldStop, pid_accel_limits))
+    if self.hybrid_tacc_enabled:
+      pid_accel_limits = tuple(l * self.hybrid_tacc_responsiveness for l in pid_accel_limits)
+      a_target = long_plan.aTarget * self.hybrid_tacc_smoothness
+    else:
+      a_target = long_plan.aTarget
+    actuators.accel = float(self.LoC.update(CC.longActive, CS, a_target, long_plan.shouldStop, pid_accel_limits))
 
     # Steering PID loop and lateral MPC
     # Reset desired curvature to current to avoid violating the limits on engage
@@ -140,6 +153,13 @@ class Controls(ControlsExt):
                                                        self.calibrated_pose, curvature_limited)  # TODO what if not available
     actuators.torque = float(steer)
     actuators.steeringAngleDeg = float(steeringAngleDeg)
+    if self.hybrid_tacc_enabled:
+      if self.experimental_mode and CS.brakePressed:
+        self.hybrid_tacc_switch_bias = max(0.0, self.hybrid_tacc_switch_bias - 0.01)
+        self.params.put("HybridTACC_SwitchBias", f"{self.hybrid_tacc_switch_bias:.3f}")
+      if not self.experimental_mode and CS.gasPressed:
+        self.hybrid_tacc_switch_bias = min(1.0, self.hybrid_tacc_switch_bias + 0.01)
+        self.params.put("HybridTACC_SwitchBias", f"{self.hybrid_tacc_switch_bias:.3f}")
     # Ensure no NaNs/Infs
     for p in ACTUATOR_FIELDS:
       attr = getattr(actuators, p)
@@ -225,6 +245,22 @@ class Controls(ControlsExt):
     cc_send.valid = CS.canValid
     cc_send.carControl = CC
     self.pm.send('carControl', cc_send)
+
+    if self.hybrid_tacc_enabled:
+      events_sp = []
+      if self.experimental_mode:
+        e = custom.OnroadEventSP.Event.new_message()
+        e.name = custom.OnroadEventSP.EventName.hybridTaccActive
+        events_sp.append(e)
+        if not self.prev_experimental_mode:
+          e2 = custom.OnroadEventSP.Event.new_message()
+          e2.name = custom.OnroadEventSP.EventName.hybridTaccAutoSwitch
+          events_sp.append(e2)
+      if events_sp:
+        evt = messaging.new_message('onroadEventsSP')
+        evt.onroadEventsSP.events = events_sp
+        self.pm.send('onroadEventsSP', evt)
+      self.prev_experimental_mode = self.experimental_mode
 
   def params_thread(self, evt):
     while not evt.is_set():

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -1,4 +1,4 @@
-from openpilot.system.ui.lib.list_view import multiple_button_item, toggle_item
+from openpilot.system.ui.lib.list_view import multiple_button_item, toggle_item, slider_item
 from openpilot.system.ui.lib.scroller import Scroller
 from openpilot.system.ui.lib.widget import Widget
 from openpilot.common.params import Params
@@ -83,6 +83,32 @@ class TogglesLayout(Widget):
       ),
       toggle_item(
         "Use Metric System", DESCRIPTIONS["IsMetric"], self._params.get_bool("IsMetric"), icon="monitoring.png"
+      ),
+      toggle_item(
+        "HybridTACC (Beta)",
+        initial_state=self._params.get_bool("HybridTACCEnabled"),
+        icon="hybrid_tacc.png",
+      ),
+      slider_item(
+        "HybridTACC Smoothness",
+        "Smooth \u2194 Aggressive",
+        float(self._params.get("HybridTACC_Smoothness") or 0.5),
+        callback=lambda v: self._params.put("HybridTACC_Smoothness", str(v)),
+        icon="smoothness.png",
+      ),
+      slider_item(
+        "HybridTACC Responsiveness",
+        "Comfort \u2194 Responsive",
+        float(self._params.get("HybridTACC_Responsiveness") or 0.5),
+        callback=lambda v: self._params.put("HybridTACC_Responsiveness", str(v)),
+        icon="responsiveness.png",
+      ),
+      slider_item(
+        "HybridTACC Switch Bias",
+        "Conservative \u2194 Experimental",
+        float(self._params.get("HybridTACC_SwitchBias") or 0.5),
+        callback=lambda v: self._params.put("HybridTACC_SwitchBias", str(v)),
+        icon="switch_bias.png",
       ),
     ]
 

--- a/selfdrive/ui/onroad/alert_renderer.py
+++ b/selfdrive/ui/onroad/alert_renderer.py
@@ -1,7 +1,7 @@
 import time
 import pyray as rl
 from dataclasses import dataclass
-from cereal import messaging, log
+from cereal import messaging, log, custom
 from openpilot.system.hardware import TICI
 from openpilot.system.ui.lib.application import gui_app, FontWeight, DEFAULT_FPS
 from openpilot.system.ui.lib.label import gui_text_box
@@ -35,6 +35,7 @@ class Alert:
   text2: str = ""
   size: int = 0
   status: int = 0
+  icon: str | None = None
 
 
 # Pre-defined alert instances
@@ -69,6 +70,14 @@ class AlertRenderer(Widget):
   def get_alert(self, sm: messaging.SubMaster) -> Alert | None:
     """Generate the current alert based on selfdrive state."""
     ss = sm['selfdriveState']
+    if sm.updated.get('onroadEventsSP', False):
+      for e in sm['onroadEventsSP'].events:
+        if e.name == custom.OnroadEventSP.EventName.hybridTaccActive:
+          return Alert(text1="Hybrid TACC Active", size=log.SelfdriveState.AlertSize.small,
+                       status=log.SelfdriveState.AlertStatus.normal, icon="hybrid_tacc.png")
+        if e.name == custom.OnroadEventSP.EventName.hybridTaccAutoSwitch:
+          return Alert(text1="Hybrid TACC Auto Switch", size=log.SelfdriveState.AlertSize.small,
+                       status=log.SelfdriveState.AlertStatus.userPrompt, icon="hybrid_tacc.png")
 
     # Check if selfdriveState messages have stopped arriving
     if not sm.updated['selfdriveState']:
@@ -136,6 +145,12 @@ class AlertRenderer(Widget):
       rl.draw_rectangle_rec(rect, color)
 
   def _draw_text(self, rect: rl.Rectangle, alert: Alert) -> None:
+    if alert.icon:
+      icon_tex = gui_app.texture(f"icons/{alert.icon}", 100, 100)
+      rl.draw_texture(icon_tex, int(rect.x), int(rect.y), rl.WHITE)
+      rect.x += icon_tex.width + 20
+      rect.width -= icon_tex.width + 20
+
     if alert.size == log.SelfdriveState.AlertSize.small:
       self._draw_centered(alert.text1, rect, self.font_bold, ALERT_FONT_MEDIUM)
 

--- a/sunnypilot/selfdrive/controls/controlsd_ext.py
+++ b/sunnypilot/selfdrive/controls/controlsd_ext.py
@@ -27,11 +27,16 @@ class ControlsExt:
     cloudlog.info("controlsd_ext got CarParamsSP")
 
     self.sm_services_ext = ['selfdriveStateSP']
-    self.pm_services_ext = ['carControlSP']
+    self.pm_services_ext = ['carControlSP', 'onroadEventsSP']
 
   def get_params_sp(self) -> None:
     self.param_store.update(self.params)
     self.blinker_pause_lateral.get_params()
+    self.hybrid_tacc_enabled = self.params.get_bool("HybridTACCEnabled")
+    self.hybrid_tacc_smoothness = float(self.params.get("HybridTACC_Smoothness") or 0.5)
+    self.hybrid_tacc_responsiveness = float(self.params.get("HybridTACC_Responsiveness") or 0.5)
+    self.hybrid_tacc_switch_bias = float(self.params.get("HybridTACC_SwitchBias") or 0.5)
+    self.experimental_mode = self.params.get_bool("ExperimentalMode")
 
   def get_lat_active(self, sm: messaging.SubMaster) -> bool:
     if self.blinker_pause_lateral.update(sm['carState']):
@@ -51,6 +56,9 @@ class ControlsExt:
     CC_SP.mads = sm['selfdriveStateSP'].mads
 
     CC_SP.params = self.param_store.publish()
+    CC_SP.hybridTACCEnabled = self.hybrid_tacc_enabled
+    CC_SP.experimentalMode = self.experimental_mode
+    CC_SP.visualAlert = sm['selfdriveState'].alertHudVisual
 
     return CC_SP
 

--- a/sunnypilot/selfdrive/controls/lib/param_store.py
+++ b/sunnypilot/selfdrive/controls/lib/param_store.py
@@ -17,12 +17,29 @@ class ParamStore:
   values: dict[str, str]
 
   def __init__(self, CP: structs.CarParams):
-    universal_params: list[str] = []
+    universal_params: list[str] = [
+      "HybridTACCEnabled",
+      "HybridTACC_Smoothness",
+      "HybridTACC_Responsiveness",
+      "HybridTACC_SwitchBias",
+    ]
     brand_params: list[str] = []
 
     self.keys = universal_params + brand_params
     self.values = {}
     self.cached_params_list: list[capnp.lib.capnp._DynamicStructBuilder] | None = None
+
+    # initialize defaults if unset
+    p = Params()
+    defaults = {
+      "HybridTACCEnabled": "0",
+      "HybridTACC_Smoothness": "0.5",
+      "HybridTACC_Responsiveness": "0.5",
+      "HybridTACC_SwitchBias": "0.5",
+    }
+    for k, v in defaults.items():
+      if p.get(k) is None:
+        p.put(k, v)
 
   def update(self, params: Params) -> None:
     old_values = dict(self.values)

--- a/sunnypilot/selfdrive/selfdrived/events.py
+++ b/sunnypilot/selfdrive/selfdrived/events.py
@@ -132,6 +132,22 @@ EVENTS_SP: dict[int, dict[str, Alert | AlertCallbackType]] = {
 
   EventNameSP.pedalPressedAlertOnly: {
     ET.WARNING: NoEntryAlert("Pedal Pressed")
-  }
+  },
+
+  EventNameSP.hybridTaccActive: {
+    ET.WARNING: Alert(
+      "Hybrid TACC Active",
+      "",
+      AlertStatus.normal, AlertSize.small,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, 1.),
+  },
+
+  EventNameSP.hybridTaccAutoSwitch: {
+    ET.WARNING: Alert(
+      "Hybrid TACC Auto Switch",
+      "",
+      AlertStatus.userPrompt, AlertSize.small,
+      Priority.LOW, VisualAlert.none, AudibleAlert.none, 1.),
+  },
 
 }

--- a/system/ui/lib/list_view.py
+++ b/system/ui/lib/list_view.py
@@ -199,6 +199,22 @@ class MultipleButtonAction(ItemAction):
     return False
 
 
+class SliderAction(ItemAction):
+  def __init__(self, initial: float = 0.0, callback: Callable[[float], None] | None = None, width: int = 400):
+    super().__init__(width)
+    self.value = initial
+    self.callback = callback
+
+  def _render(self, rect: rl.Rectangle) -> bool:
+    slider_rect = rl.Rectangle(rect.x, rect.y + (rect.height - 40) / 2, self._rect.width, 40)
+    new_val = rl.gui_slider_bar(slider_rect, "", "", self.value, 0.0, 1.0)
+    if abs(new_val - self.value) > 1e-3:
+      self.value = new_val
+      if self.callback:
+        self.callback(self.value)
+    return False
+
+
 class ListItem(Widget):
   def __init__(self, title: str = "", icon: str | None = None, description: str | Callable[[], str] | None = None,
                description_visible: bool = False, callback: Callable | None = None,
@@ -365,4 +381,9 @@ def dual_button_item(left_text: str, right_text: str, left_callback: Callable = 
 def multiple_button_item(title: str, description: str, buttons: list[str], selected_index: int,
                          button_width: int = BUTTON_WIDTH, callback: Callable = None, icon: str = ""):
   action = MultipleButtonAction(buttons, button_width, selected_index, callback=callback)
+  return ListItem(title=title, description=description, icon=icon, action_item=action)
+
+
+def slider_item(title: str, description: str, initial: float, callback: Callable[[float], None] | None = None, icon: str = ""):
+  action = SliderAction(initial, callback)
   return ListItem(title=title, description=description, icon=icon, action_item=action)


### PR DESCRIPTION
## Summary
- add Hybrid TACC params with defaults and schema support
- expose Hybrid TACC controls and telemetry through settings UI and control loop
- show Hybrid TACC alerts and icons on-road

## Testing
- `scons -u cereal` *(fails: command not found)*
- `pip install scons` *(fails: Could not find a version that satisfies the requirement scons)*
- `pytest selfdrive/ui/tests/test_ui/run.py -q` *(fails: ModuleNotFoundError: No module named 'openpilot.common.params_pyx')*


------
https://chatgpt.com/codex/tasks/task_e_68912db3c19083289e2336f340a3e424