### PR TITLE
Add AALC configuration

### DIFF
--- a/common/params.py
+++ b/common/params.py
@@ -3,6 +3,10 @@ assert Params
 assert ParamKeyType
 assert UnknownKeyName
 
+# Auto Assisted Lane Change parameters
+AALC_ENABLED = "AALCEnabled"
+AALC_MODE = "AALCMode"
+
 if __name__ == "__main__":
   import sys
 

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -124,8 +124,9 @@ inline static std::unordered_map<std::string, uint32_t> keys = {
 
     // --- sunnypilot params --- //
     {"ApiCache_DriveStats", PERSISTENT},
+    {"AALCEnabled", PERSISTENT | BACKUP},
+    {"AALCMode", PERSISTENT},
     {"AutoLaneChangeBsmDelay", PERSISTENT},
-    {"AutoLaneChangeTimer", PERSISTENT},
     {"BlinkerMinLateralControlSpeed", PERSISTENT | BACKUP},
     {"BlinkerPauseLateralControl", PERSISTENT | BACKUP},
     {"Brightness", PERSISTENT | BACKUP},

--- a/selfdrive/ui/layouts/settings/toggles.py
+++ b/selfdrive/ui/layouts/settings/toggles.py
@@ -30,6 +30,24 @@ class TogglesLayout(Widget):
   def __init__(self):
     super().__init__()
     self._params = Params()
+    self._aalc_toggle = toggle_item(
+      "Allow Auto Lane Change",
+      "Automatically start lane changes after a short delay when the turn signal is on.",
+      self._params.get_bool("AALCEnabled"),
+      icon="road.png",
+    )
+    self._aalc_mode = multiple_button_item(
+      "Auto Lane Change Delay",
+      "Delay before automatic lane changes begin.",
+      buttons=["Nudgeless", "0.5s", "1s", "2s", "3s"],
+      button_width=255,
+      selected_index=max(0, int(self._params.get("AALCMode") or b"1") - 1),
+      callback=self._set_aalc_mode,
+      icon="road.png",
+    )
+    self._aalc_toggle_prev = self._aalc_toggle.action_item.toggle.get_state()
+    self._aalc_mode_prev = self._aalc_mode.action_item.selected_button
+
     items = [
       toggle_item(
         "Enable openpilot",
@@ -81,6 +99,8 @@ class TogglesLayout(Widget):
         self._params.get_bool("RecordAudio"),
         icon="microphone.png",
       ),
+      self._aalc_toggle,
+      self._aalc_mode,
       toggle_item(
         "Use Metric System", DESCRIPTIONS["IsMetric"], self._params.get_bool("IsMetric"), icon="monitoring.png"
       ),
@@ -91,5 +111,18 @@ class TogglesLayout(Widget):
   def _render(self, rect):
     self._scroller.render(rect)
 
+    enabled = self._aalc_toggle.action_item.toggle.get_state()
+    if enabled != self._aalc_toggle_prev:
+      self._aalc_toggle_prev = enabled
+      self._params.put_bool("AALCEnabled", enabled)
+
+    mode_index = self._aalc_mode.action_item.selected_button
+    if mode_index != self._aalc_mode_prev:
+      self._aalc_mode_prev = mode_index
+      self._params.put("AALCMode", str(mode_index + 1))
+
   def _set_longitudinal_personality(self, button_index: int):
     self._params.put("LongitudinalPersonality", str(button_index))
+
+  def _set_aalc_mode(self, button_index: int):
+    self._params.put("AALCMode", str(button_index + 1))

--- a/sunnypilot/selfdrive/controls/lib/auto_lane_change.py
+++ b/sunnypilot/selfdrive/controls/lib/auto_lane_change.py
@@ -44,6 +44,7 @@ class AutoLaneChangeController:
 
     self.lane_change_set_timer = AutoLaneChangeMode.NUDGE
     self.lane_change_bsm_delay = False
+    self.aalc_enabled = False
 
     self.prev_brake_pressed = False
     self.auto_lane_change_allowed = False
@@ -60,9 +61,10 @@ class AutoLaneChangeController:
       self.prev_lane_change = False
 
   def read_params(self) -> None:
+    self.aalc_enabled = self.params.get_bool("AALCEnabled")
     self.lane_change_bsm_delay = self.params.get_bool("AutoLaneChangeBsmDelay")
     try:
-      self.lane_change_set_timer = int(self.params.get("AutoLaneChangeTimer", encoding="utf8"))
+      self.lane_change_set_timer = int(self.params.get("AALCMode", encoding="utf8"))
     except (ValueError, TypeError):
       self.lane_change_set_timer = AutoLaneChangeMode.NUDGE
 
@@ -89,6 +91,9 @@ class AutoLaneChangeController:
     # 2. Brake wasn't previously pressed
     # 3. We've waited long enough
 
+    if not self.aalc_enabled:
+      return False
+
     if self.lane_change_set_timer in (AutoLaneChangeMode.OFF, AutoLaneChangeMode.NUDGE):
       return False
 
@@ -101,6 +106,11 @@ class AutoLaneChangeController:
     return bool(self.lane_change_wait_timer > self.lane_change_delay)
 
   def update_lane_change(self, blindspot_detected: bool, brake_pressed: bool) -> None:
+    if not self.aalc_enabled:
+      self.auto_lane_change_allowed = False
+      self.lane_change_wait_timer = 0.0
+      return
+
     if brake_pressed and not self.prev_brake_pressed:
       self.prev_brake_pressed = brake_pressed
 

--- a/sunnypilot/selfdrive/controls/lib/tests/test_auto_lane_change.py
+++ b/sunnypilot/selfdrive/controls/lib/tests/test_auto_lane_change.py
@@ -25,6 +25,7 @@ class TestAutoLaneChangeController:
   def setup_method(self):
     self.DH = DesireHelper()
     self.alc = AutoLaneChangeController(self.DH)
+    self.alc.aalc_enabled = True
 
   def _reset_states(self):
     self.alc.lane_change_bsm_delay = False

--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -45,7 +45,8 @@ def manager_init() -> None:
   ]
 
   sunnypilot_default_params: list[tuple[str, str | bytes]] = [
-    ("AutoLaneChangeTimer", "0"),
+    ("AALCEnabled", "0"),
+    ("AALCMode", "1"),
     ("AutoLaneChangeBsmDelay", "0"),
     ("BlindSpot", "0"),
     ("BlinkerMinLateralControlSpeed", "20"),  # MPH or km/h


### PR DESCRIPTION
## Summary
- add AALC param keys and defaults
- gate auto lane change logic on new params
- expose AALC toggle and delay setting in UI

## Testing
- `pytest sunnypilot/selfdrive/controls/lib/tests/test_auto_lane_change.py` *(fails: ImportError: /workspace/openpilot/openpilot/common/params_pyx.so: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f76094e1483289eddf284c3f72ec8